### PR TITLE
Fix the issue that walk_log cannot handle annotated tag sha

### DIFF
--- a/lib/grit/git-ruby/repository.rb
+++ b/lib/grit/git-ruby/repository.rb
@@ -333,8 +333,11 @@ module Grit
         if (sha)
           o = get_raw_object_by_sha1(sha)
           if o.type == :tag
-            commit_sha = get_object_by_sha1(sha).object
-            c = get_object_by_sha1(commit_sha)
+            c = loop do
+              sha = get_object_by_sha1(sha).object
+              deref = get_object_by_sha1(sha)
+              break deref unless deref.type == :tag
+            end
           else
             c = GitObject.from_raw(o)
           end


### PR DESCRIPTION
解决了当将 annotated tag 的 SHA-1 传入 Grit::GitRuby::Repository#walk_log 后返回的 commit 的 SHA 错误的 bug
